### PR TITLE
Add flake8 configuration and fix flake8 errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+exclude = .git,__pycache__,./migrations,./venv
+max-complexity = 10
+max_line_length = 119
+per-file-ignores =
+    # imported but unused
+    __init__.py: F401

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ pizza.sqlite
 .vscode/tasks.json
 .vscode/settings.json
 
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "liveServer.settings.root": "/ui"
+    "liveServer.settings.root": "/ui",
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
 }

--- a/app/repositories/managers.py
+++ b/app/repositories/managers.py
@@ -3,8 +3,7 @@ from typing import Any, List, Optional, Sequence
 from sqlalchemy.sql import text, column
 
 from .models import Ingredient, Order, OrderDetail, Size, db
-from .serializers import (IngredientSerializer, OrderSerializer,
-                          SizeSerializer, ma)
+from .serializers import IngredientSerializer, OrderSerializer, SizeSerializer, ma
 
 
 class BaseManager:
@@ -50,7 +49,9 @@ class IngredientManager(BaseManager):
 
     @classmethod
     def get_by_id_list(cls, ids: Sequence):
-        return cls.session.query(cls.model).filter(cls.model._id.in_(set(ids))).all() or []
+        return (
+            cls.session.query(cls.model).filter(cls.model._id.in_(set(ids))).all() or []
+        )
 
 
 class OrderManager(BaseManager):
@@ -63,18 +64,25 @@ class OrderManager(BaseManager):
         cls.session.add(new_order)
         cls.session.flush()
         cls.session.refresh(new_order)
-        cls.session.add_all((OrderDetail(order_id=new_order._id, ingredient_id=ingredient._id, ingredient_price=ingredient.price)
-                             for ingredient in ingredients))
+        cls.session.add_all(
+            (
+                OrderDetail(
+                    order_id=new_order._id,
+                    ingredient_id=ingredient._id,
+                    ingredient_price=ingredient.price,
+                )
+                for ingredient in ingredients
+            )
+        )
         cls.session.commit()
         return cls.serializer().dump(new_order)
 
     @classmethod
     def update(cls):
-        raise NotImplementedError(f'Method not suported for {cls.__name__}')
+        raise NotImplementedError(f"Method not suported for {cls.__name__}")
 
 
 class IndexManager(BaseManager):
-
     @classmethod
     def test_connection(cls):
-        cls.session.query(column('1')).from_statement(text('SELECT 1')).all()
+        cls.session.query(column("1")).from_statement(text("SELECT 1")).all()

--- a/app/test/controllers/test_order.py
+++ b/app/test/controllers/test_order.py
@@ -50,7 +50,9 @@ def test_calculate_order_price(app, ingredients, size, client_data):
     created_size, created_ingredients = __create_sizes_and_ingredients(ingredients, [size])
     order = __order(created_ingredients, created_size, client_data)
     created_order, _ = OrderController.create(order)
-    pytest.assume(created_order['total_price'] == round(created_size['price'] + sum(ingredient['price'] for ingredient in created_ingredients), 2))
+    pytest.assume(created_order['total_price'] == round(
+        created_size['price'] + sum(ingredient['price'] for ingredient in created_ingredients), 2
+        ))
 
 
 def test_get_by_id(app, ingredients, size, client_data):


### PR DESCRIPTION
This pull request will add a flake8 configuration for the project. Flake8 is a code format checker that we will use in our Continous Integration pipeline.
I'm creating a flake8 config file with the following criteria:
- Exclude .git files, __pycache__, ./migrations directory, ./venv directory
- max-complexity = 10
- Max line length = 119 (this is because this is the length of GitHub diff on code reviews)
- Per file ignores: imported but unused errors on __init__.py files

Also, it will correct the line length of the following files:

- ./app/test/controllers/test_order.py:53:120: E501 line too long (147 > 119 characters)
- ./app/repositories/managers.py:66:120: E501 line too long (129 > 119 characters)