### PR TITLE
PIZ1 - Fix order creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "liveServer.settings.root": "/ui",
     "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
+    "python.linting.enabled": true,
+    "python.testing.pytestArgs": [
+        "app"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,4 @@
     "liveServer.settings.root": "/ui",
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "python.testing.pytestArgs": [
-        "app"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "liveServer.settings.root": "/ui",
     "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
+    "python.linting.enabled": true
 }

--- a/app/services/size.py
+++ b/app/services/size.py
@@ -32,4 +32,7 @@ def get_size_by_id(_id: int):
 
 @size.route('/', methods=GET)
 def get_sizes():
-    pass
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,8 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    pass

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -4,4 +4,6 @@ import pytest
 def test_get_sizes_service(client, create_sizes, size_uri):
     response = client.get(size_uri)
     pytest.assume(response.status.startswith('200'))
-
+    returned_sizes = {size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
When creating an order, it wasn't showing the sizes, but they were successfully created. The reason for this error was that there wasn't an endpoint for getting sizes in the services.